### PR TITLE
[FEAT] 로그인 연장 기능 추가

### DIFF
--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
     <div className="flex flex-col gap-5">
       <DeviceInformation />
       <Separator className="w-full" />
-      <div className="w-full grid grid-cols-2 gap-5">
+      <div className="w-full grid grid-cols-1 gap-5 xl:grid-cols-2">
         <div className="col-span-1 flex flex-col gap-4">
           <h2 className="text-2xl col-span-2">최근 등록 사용자 조회</h2>
           <LatestAddUser />

--- a/src/components/Layouts/DefaultHeaderLayout.tsx
+++ b/src/components/Layouts/DefaultHeaderLayout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DarkModeToggle } from "../ui/darkmode";
 import { SidebarTrigger } from "../ui/sidebar";
 import { LayoutBreadCrumb } from "./LayoutBreadCrumb";
+import UpdateSessionButton from "../Util/UpdateSessionButton";
 
 export default function DefaultHeaderLayout() {
   return (
@@ -10,7 +11,10 @@ export default function DefaultHeaderLayout() {
         <SidebarTrigger />
         <LayoutBreadCrumb />
       </div>
-      <DarkModeToggle />
+      <div className="flex items-center gap-2 md:gap-5">
+        <UpdateSessionButton />
+        <DarkModeToggle />
+      </div>
     </header>
   );
 }

--- a/src/components/Util/UpdateSessionButton.tsx
+++ b/src/components/Util/UpdateSessionButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useLoginTimeout } from "@/hooks/utils/useLoginTimeout";
+import { Button } from "../ui/button";
+import { formatTime } from "@/utils/formatDate";
+
+const UpdateSessionButton = () => {
+  const { remainingSeconds, resetTimer } = useLoginTimeout();
+
+  const handleUpdateSession = () => {
+    resetTimer();
+    alert("로그인이 연장되었습니다.");
+  };
+  console.log(remainingSeconds);
+  return (
+    <div className="flex items-center gap-2 md:gap-4">
+      <p className="">
+        남은 시간: <strong>{formatTime(remainingSeconds)}</strong>
+      </p>
+      <Button onClick={handleUpdateSession} variant="outline">로그인 연장</Button>
+    </div>
+  );
+};
+
+export default UpdateSessionButton;

--- a/src/hooks/utils/useLoginTimeout.ts
+++ b/src/hooks/utils/useLoginTimeout.ts
@@ -23,7 +23,7 @@ export const useLoginTimeout = () => {
       if (timeLeft <= 0) {
         clearInterval(interval);
         logout();
-        alert('1분이 지나 자동 로그아웃 되었습니다.');
+        alert('15분이 지나 자동 로그아웃 되었습니다.');
         router.push('/login');
       }
     }, 1000);

--- a/src/hooks/utils/useLoginTimeout.ts
+++ b/src/hooks/utils/useLoginTimeout.ts
@@ -1,0 +1,39 @@
+import { useAuthStore } from '@/providers/AuthProvider';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+
+const SESSION_TIMEOUT = 15 * 60 * 1000; // 15분
+
+
+export const useLoginTimeout = () => {
+  const router = useRouter();
+  const logout = useAuthStore((state) => state.setLogout);
+  const [remaining, setRemaining] = useState<number>(SESSION_TIMEOUT);
+  const [now, setNow] = useState<number>(Date.now());
+  
+  const resetTimer = () => {
+    setNow(Date.now());
+  }
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const timeLeft = SESSION_TIMEOUT - (Date.now() - now);
+      setRemaining(timeLeft);
+
+      if (timeLeft <= 0) {
+        clearInterval(interval);
+        logout();
+        alert('1분이 지나 자동 로그아웃 되었습니다.');
+        router.push('/login');
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [now]);
+
+  return {
+    resetTimer,
+    remainingTimeMs: remaining,
+    remainingSeconds: Math.max(0, Math.floor(remaining / 1000)),
+  };
+};

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,3 +1,10 @@
+export const formatTime = (date: number) => {
+  const totalSeconds = date;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+};
+
 export const formatDate = (date: string) => {
   const dateObj = new Date(date);
   const year = dateObj.getFullYear();


### PR DESCRIPTION
# [FEAT] 로그인 연장 기능 추가

## 작업 내용
- 관리자의 보안에 대한 구비책으로 강제 로그아웃 및 로그인 연장 기능 도입.
- 메인페이지 반응형 수정

## 작업 키체인지
- useLoginTimeout 추가

## 작업 이미지

## 작업 관련 이슈
- closed #91