### PR TITLE
[FEAT] 비밀번호 초기화 및 신규 비밀번호 등록구현

### DIFF
--- a/src/app/(unauth)/find/page.tsx
+++ b/src/app/(unauth)/find/page.tsx
@@ -24,13 +24,11 @@ const FindPasswordPage = () => {
           <h1 className="text-2xl font-bold mb-3 lg:mb-5 text-center">
             탱고플러스 센터관리자 비밀번호 찾기
           </h1>
-          {step === 0 && (
-            <InputEmail setEmail={handleInputEmail} />
-          )}
+          {step === 0 && <InputEmail setEmail={handleInputEmail} />}
           {step === 1 && (
             <RequestOtpForm handleRequestOtp={handleRequestOtp} email={email} />
           )}
-          {step === 2 && <ResetPwd />}
+          {step === 2 && <ResetPwd jwt={jwt} email={email} />}
         </div>
       </div>
     </div>

--- a/src/components/auth/ResetPwd.tsx
+++ b/src/components/auth/ResetPwd.tsx
@@ -1,7 +1,103 @@
 import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Label } from "../ui/label";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+import { useResetPwd } from "@/hooks/api/auth/useResetPwd";
 
-const ResetPwd = () => {
-  return <div>ResetPwd</div>;
+const ResetPwd = ({ jwt, email }: { jwt: string; email: string }) => {
+  const formSchema = z
+    .object({
+      password: z
+        .string()
+        .min(1, "새 비밀번호를 입력해주세요.")
+        .min(8, "비밀번호는 최소 8글자 이상이여야 합니다.")
+        .max(16, "비밀번호는 최대 16글자 이하여야 합니다.")
+        .regex(
+          /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[a-z\d!@#$%^&*]+$/i,
+          "비밀번호는 영문, 숫자, ! ~ * 특수문자를 최소 1자리 이상 입력해야합니다.",
+        ),
+      confirmPassword: z
+        .string()
+        .min(1, "비밀번호 확인을 입력해주세요.")
+        .min(8, "비밀번호는 최소 8글자 이상이여야 합니다.")
+        .max(16, "비밀번호는 최대 16글자 이하여야 합니다.")
+        .regex(
+          /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[a-z\d!@#$%^&*]+$/i,
+          "비밀번호는 영문, 숫자, ! ~ * 특수문자를 최소 1자리 이상 입력해야합니다.",
+        ),
+    })
+    .superRefine((arg, ctx) => {
+      if (arg.password !== arg.confirmPassword) {
+        return ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "비밀번호가 일치하지 않습니다.",
+          path: ["confirmPassword"],
+        });
+      }
+    });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  });
+  const { mutate: resetPwd } = useResetPwd();
+
+  const onSubmit = (data: z.infer<typeof formSchema>) => {
+    const password = data.password;
+    resetPwd({
+      jwt,
+      new_password: password,
+      email_or_mobile: email,
+      type: "email",
+      purpose: "password",
+    });
+  };
+  return (
+    <form
+      onSubmit={form.handleSubmit(onSubmit)}
+      className="w-full flex flex-col gap-2"
+    >
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="password">신규 비밀번호</Label>
+        <Input
+          {...form.register("password")}
+          type="password"
+          id="password"
+          defaultValue=""
+          placeholder="새 비밀번호"
+          className="bg-white"
+        />
+        {form.formState.errors.password?.message && (
+          <p className="text-sm text-red-500">
+            {form.formState.errors.password.message.toString()}
+          </p>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="confirmPassword">비밀번호 확인</Label>
+        <Input
+          {...form.register("confirmPassword")}
+          type="password"
+          id="confirmPassword"
+          defaultValue=""
+          placeholder="비밀번호 확인"
+          className="bg-white"
+        />
+        {form.formState.errors.confirmPassword?.message && (
+          <p className="text-sm text-red-500">
+            {form.formState.errors.confirmPassword.message.toString()}
+          </p>
+        )}
+      </div>
+      <Button type="submit">비밀번호 변경</Button>
+    </form>
+  );
 };
 
 export default ResetPwd;

--- a/src/hooks/api/auth/useResetPwd.ts
+++ b/src/hooks/api/auth/useResetPwd.ts
@@ -1,8 +1,17 @@
 import { useMutation } from "@tanstack/react-query";
 import { postResetPwd } from "@/services/auth/postResetPwd";
+import { useRouter } from "next/navigation";
 
 export const useResetPwd = () => {
+  const router = useRouter();
   return useMutation({
     mutationFn: postResetPwd,
+    onSuccess: () => {
+      alert("비밀번호가 변경되었습니다.");
+      router.push("/login");
+    },
+    onError: () => {
+      alert("비밀번호 변경에 실패했습니다.");
+    },
   });
 };

--- a/src/services/auth/postResetPwd.ts
+++ b/src/services/auth/postResetPwd.ts
@@ -1,18 +1,27 @@
 import { customUnAuthAxios } from "@/lib/axios";
 import { IResponseDefault } from "@/types/default";
-import { IOtpProps } from "@/types/admin";
+import { IResetPwdProps } from "@/types/admin";
 
 export const postResetPwd = async ({
   email_or_mobile,
   type,
   purpose,
-}: IOtpProps) => {
+  jwt,
+  new_password,
+}: IResetPwdProps) => {
   const { data } = await customUnAuthAxios.post<IResponseDefault>(
     "/otp/reset-pwd",
     {
       email_or_mobile,
       type,
       purpose,
+      new_password,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
     },
   );
+  return data;
 };

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -10,3 +10,8 @@ export interface IOtpProps {
 export interface IOtpVerifyProps extends IOtpProps {
   otp: string;
 }
+
+export interface IResetPwdProps extends IOtpProps {
+  jwt: string;
+  new_password: string;
+}


### PR DESCRIPTION
# [FEAT] 비밀번호 초기화 및 신규 비밀번호 등록구현

## 작업 내용
- OTP 통과 시 신규 비밀번호를 입력하여 JWT와 함께 보내 신규비밀번호 갱신 구현

## 작업 키체인지


## 작업 이미지
### 1. 이메일 인증 
  <img width="598" height="251" alt="스크린샷 2025-07-23 오후 4 29 03" src="https://github.com/user-attachments/assets/8f5d4092-8728-4081-bf65-39852621517d" />

### 2. OTP 이메일 확인
<img width="865" height="581" alt="스크린샷 2025-07-23 오후 4 29 15" src="https://github.com/user-attachments/assets/6518f62e-1ce2-4b97-aac7-b995e120505d" />

### 3. OTP 입력
<img width="436" height="241" alt="스크린샷 2025-07-23 오후 4 29 58" src="https://github.com/user-attachments/assets/f2a1754a-1800-4c50-a75f-137683aa40ac" />

### 4. 신규 비밀번호 입력
<img width="638" height="325" alt="스크린샷 2025-07-23 오후 4 30 08" src="https://github.com/user-attachments/assets/f3f6eb9e-8de6-44dc-80ca-781d94058aee" />



## 작업 관련 이슈
- #93 
- #94 