### PR TITLE
ResultGraph 컴포넌트 사용 시 unitName prop 제거 - TypeScript 오류 해결

### DIFF
--- a/src/components/Measure/DetailDynamic.tsx
+++ b/src/components/Measure/DetailDynamic.tsx
@@ -419,12 +419,10 @@ const MeasureDetailDynamic = ({
             title="오버헤드스쿼트 양쪽 어깨 높이차"
             userAvg={dynamic.ohs_front_horizontal_distance_shoulder}
             unit="cm"
-            unitName="높이차"
           />
           <ResultGraph
             defaultAvg={89.9 * 2}
             sdAvg={1.93 * 2}
-            unitName="기울기"
             title="오버헤드스쿼트 양쪽 어깨 기울기"
             userAvg={Math.abs(dynamic.ohs_front_horizontal_angle_shoulder)}
             unit="°"
@@ -436,13 +434,11 @@ const MeasureDetailDynamic = ({
             sdAvg={1.16}
             title="오버헤드스쿼트 양쪽 팔꿉 높이차"
             userAvg={dynamic.ohs_front_horizontal_distance_elbow}
-            unitName="높이차"
             unit="cm"
           />
           <ResultGraph
             defaultAvg={90.39 * 2}
             sdAvg={2.44 * 2}
-            unitName="기울기"
             title="오버헤드스쿼트 양쪽 팔꿉 기울기"
             userAvg={Math.abs(dynamic.ohs_front_horizontal_angle_elbow)}
             unit="°"
@@ -453,14 +449,12 @@ const MeasureDetailDynamic = ({
             defaultAvg={0.5}
             sdAvg={1.52}
             title="오버헤드스쿼트 양쪽 손목 높이차"
-            unitName="높이차"
             userAvg={dynamic.ohs_front_horizontal_distance_wrist}
             unit="cm"
           />
           <ResultGraph
             defaultAvg={89.89 * 2}
             sdAvg={2.98 * 2}
-            unitName="기울기"
             title="오버헤드스쿼트 양쪽 손목 기울기"
             userAvg={Math.abs(dynamic.ohs_front_horizontal_angle_wrist)}
             unit="°"
@@ -470,7 +464,6 @@ const MeasureDetailDynamic = ({
           <ResultGraph
             defaultAvg={-0.18}
             sdAvg={0.28}
-            unitName="높이차"
             title="오버헤드스쿼트 양쪽 골반 높이차"
             userAvg={dynamic.ohs_front_horizontal_distance_hip}
             unit="cm"
@@ -478,7 +471,6 @@ const MeasureDetailDynamic = ({
           <ResultGraph
             defaultAvg={90.99 * 2}
             sdAvg={1.56 * 2}
-            unitName="기울기"
             title="오버헤드스쿼트 양쪽 골반 기울기"
             userAvg={Math.abs(dynamic.ohs_front_horizontal_angle_hip)}
             unit="°"
@@ -488,7 +480,6 @@ const MeasureDetailDynamic = ({
           <ResultGraph
             defaultAvg={-0.22}
             sdAvg={0.54}
-            unitName="높이차"
             title="오버헤드스쿼트 양쪽 무릎 높이차"
             userAvg={dynamic.ohs_front_horizontal_distance_knee}
             unit="cm"
@@ -496,7 +487,6 @@ const MeasureDetailDynamic = ({
           <ResultGraph
             defaultAvg={91.02 * 2}
             sdAvg={2.57 * 2}
-            unitName="기울기"
             title="오버헤드스쿼트 양쪽 무릎 기울기"
             userAvg={Math.abs(dynamic.ohs_front_horizontal_angle_knee)}
             unit="°"

--- a/src/components/Measure/Static/Fifth.tsx
+++ b/src/components/Measure/Static/Fifth.tsx
@@ -38,7 +38,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={0.1}
               sdAvg={0.23}
-              unitName="높이차"
               title="후면 양쪽 귀 높이차"
               userAvg={statics.back_horizontal_distance_sub_ear}
               unit="cm"
@@ -46,7 +45,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={86.5}
               sdAvg={21.14}
-              unitName="기울기"
               title="후면 양쪽 귀 기울기"
               userAvg={90 - statics.back_horizontal_angle_ear}
               unit="°"
@@ -56,7 +54,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={-0.13}
               sdAvg={0.51}
-              unitName="높이차"
               title="후면 양쪽 어깨 높이차"
               userAvg={statics.back_horizontal_distance_sub_shoulder}
               unit="cm"
@@ -64,7 +61,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={89.27}
               sdAvg={14.88}
-              unitName="기울기"
               title="후면 양쪽 어깨 기울기"
               userAvg={90 - statics.back_horizontal_angle_shoulder}
               unit="°"
@@ -74,7 +70,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={-0.14}
               sdAvg={0.83}
-              unitName="높이차"
               title="후면 양쪽 팔꿉 높이차"
               userAvg={statics.back_horizontal_distance_sub_elbow}
               unit="cm"
@@ -82,7 +77,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={89.16}
               sdAvg={15.15}
-              unitName="기울기"
               title="후면 양쪽 팔꿉 기울기"
               userAvg={90 - statics.back_horizontal_angle_elbow}
               unit="°"
@@ -92,7 +86,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={0.12}
               sdAvg={0.21}
-              unitName="높이차"
               title="후면 양쪽 골반 높이차"
               userAvg={statics.back_horizontal_distance_sub_hip}
               unit="cm"
@@ -100,7 +93,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={88.07}
               sdAvg={14.86}
-              unitName="기울기"
               title="후면 양쪽 골반 기울기"
               userAvg={90 - statics.back_horizontal_angle_hip}
               unit="°"
@@ -110,7 +102,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={-0.01}
               sdAvg={0.57}
-              unitName="높이차"
               title="후면 양쪽 발목 높이차"
               userAvg={statics.back_horizontal_distance_sub_ankle}
               unit="cm"
@@ -118,7 +109,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={88.85}
               sdAvg={15.51}
-              unitName="기울기"
               title="후면 양쪽 발목 기울기"
               userAvg={90 - statics.back_horizontal_angle_ankle}
               unit="°"
@@ -128,7 +118,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={5.03}
               sdAvg={1.27}
-              unitName="높이차"
               title="후면 왼쪽 무릎 거리"
               userAvg={statics.back_horizontal_distance_knee_left}
               unit="cm"
@@ -136,7 +125,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={4.79}
               sdAvg={1.24}
-              unitName="높이차"
               title="후면 오른쪽 무릎 거리"
               userAvg={statics.back_horizontal_distance_knee_right}
               unit="cm"
@@ -146,7 +134,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={-27.35}
               sdAvg={174.14}
-              unitName="각도"
               title="후면 왼쪽 무릎-뒤꿈치 각도"
               userAvg={statics.back_vertical_angle_knee_heel_left - 90}
               unit="°"
@@ -154,7 +141,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={8.49}
               sdAvg={176.42}
-              unitName="각도"
               title="후면 오른쪽 무릎-뒤꿈치 각도"
               userAvg={statics.back_vertical_angle_knee_heel_right - 90}
               unit="°"
@@ -164,7 +150,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={-39.92}
               sdAvg={174.14}
-              unitName="각도"
               title="후면 코-어깨-중심점 각도"
               userAvg={statics.back_vertical_angle_nose_center_shoulder - 90}
               unit="°"
@@ -172,7 +157,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={-20.82}
               sdAvg={175.28}
-              unitName="각도"
               title="후면 코-골반-중심점 각도"
               userAvg={statics.back_vertical_angle_nose_center_hip - 90}
               unit="°"
@@ -182,7 +166,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={3.85}
               sdAvg={1.5}
-              unitName="거리"
               title="후면 중심점-발뒤꿈치 거리"
               userAvg={statics.back_horizontal_distance_heel_left}
               unit="cm"
@@ -190,7 +173,6 @@ const MeasureStaticFifth = React.memo(
             <ResultGraph
               defaultAvg={3.82}
               sdAvg={1.62}
-              unitName="거리"
               title="후면 오른쪽 무릎-뒤꿈치 거리"
               userAvg={statics.back_horizontal_distance_heel_right}
               unit="cm"

--- a/src/components/Measure/Static/First copy.tsx
+++ b/src/components/Measure/Static/First copy.tsx
@@ -38,7 +38,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={0.1}
               sdAvg={0.23}
-              unitName="높이차"
               title="후면 양쪽 귀 높이차"
               userAvg={statics.back_horizontal_distance_sub_ear}
               unit="cm"
@@ -46,7 +45,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={86.5}
               sdAvg={21.14}
-              unitName="기울기"
               title="후면 양쪽 귀 기울기"
               userAvg={90 - statics.back_horizontal_angle_ear}
               unit="°"
@@ -56,7 +54,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.13}
               sdAvg={0.51}
-              unitName="높이차"
               title="후면 양쪽 어깨 높이차"
               userAvg={statics.back_horizontal_distance_sub_shoulder}
               unit="cm"
@@ -64,7 +61,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={89.27}
               sdAvg={14.88}
-              unitName="기울기"
               title="후면 양쪽 어깨 기울기"
               userAvg={90 - statics.back_horizontal_angle_shoulder}
               unit="°"
@@ -74,7 +70,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.14}
               sdAvg={0.83}
-              unitName="높이차"
               title="후면 양쪽 팔꿉 높이차"
               userAvg={statics.back_horizontal_distance_sub_elbow}
               unit="cm"
@@ -82,7 +77,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={89.16}
               sdAvg={15.15}
-              unitName="기울기"
               title="후면 양쪽 팔꿉 기울기"
               userAvg={90 - statics.back_horizontal_angle_elbow}
               unit="°"
@@ -93,7 +87,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={0.12}
               sdAvg={0.21}
-              unitName="높이차"
               title="후면 양쪽 골반 높이차"
               userAvg={statics.back_horizontal_distance_sub_hip}
               unit="cm"
@@ -101,7 +94,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={88.07}
               sdAvg={14.86}
-              unitName="기울기"
               title="후면 양쪽 골반 기울기"
               userAvg={90 - statics.back_horizontal_angle_hip}
               unit="°"
@@ -112,7 +104,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.01}
               sdAvg={0.57}
-              unitName="높이차"
               title="후면 양쪽 발목 높이차"
               userAvg={statics.back_horizontal_distance_sub_ankle}
               unit="cm"
@@ -120,7 +111,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={88.85}
               sdAvg={15.51}
-              unitName="기울기"
               title="후면 양쪽 발목 기울기"
               userAvg={90 - statics.back_horizontal_angle_ankle}
               unit="°"
@@ -130,7 +120,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={5.03}
               sdAvg={1.27}
-              unitName="높이차"
               title="후면 왼쪽 무릎 거리"
               userAvg={statics.back_horizontal_distance_knee_left}
               unit="cm"
@@ -138,7 +127,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={4.79}
               sdAvg={1.24}
-              unitName="높이차"
               title="후면 오른쪽 무릎 거리"
               userAvg={statics.back_horizontal_distance_knee_right}
               unit="cm"
@@ -148,7 +136,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-27.35}
               sdAvg={174.14}
-              unitName="각도"
               title="후면 왼쪽 무릎-뒤꿈치 각도"
               userAvg={statics.back_vertical_angle_knee_heel_left - 90}
               unit="°"
@@ -156,7 +143,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={8.49}
               sdAvg={176.42}
-              unitName="각도"
               title="후면 오른쪽 무릎-뒤꿈치 각도"
               userAvg={statics.back_vertical_angle_knee_heel_right - 90}
               unit="°"
@@ -166,7 +152,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-39.92}
               sdAvg={174.14}
-              unitName="각도"
               title="후면 코-어깨-중심점 각도"
               userAvg={statics.back_vertical_angle_nose_center_shoulder - 90}
               unit="°"
@@ -174,7 +159,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-20.82}
               sdAvg={175.28}
-              unitName="각도"
               title="후면 코-골반-중심점 각도"
               userAvg={statics.back_vertical_angle_nose_center_hip - 90}
               unit="°"
@@ -184,7 +168,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={3.85}
               sdAvg={1.5}
-              unitName="거리"
               title="후면 중심점-발뒤꿈치 거리"
               userAvg={statics.back_horizontal_distance_heel_left}
               unit="cm"
@@ -192,7 +175,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={3.82}
               sdAvg={1.62}
-              unitName="거리"
               title="후면 오른쪽 무릎-뒤꿈치 거리"
               userAvg={statics.back_horizontal_distance_heel_right}
               unit="cm"

--- a/src/components/Measure/Static/First.tsx
+++ b/src/components/Measure/Static/First.tsx
@@ -38,7 +38,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.1}
               sdAvg={0.23}
-              unitName="높이차"
               title="정면 양쪽 귀 높이차"
               userAvg={statics.front_horizontal_distance_sub_ear}
               unit="cm"
@@ -46,7 +45,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={90.11 * 2}
               sdAvg={2.51 * 2}
-              unitName="기울기"
               title="정면 양쪽 귀 기울기"
               userAvg={Math.abs(statics.front_horizontal_angle_ear)}
               unit="°"
@@ -56,7 +54,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.1}
               sdAvg={0.45}
-              unitName="높이차"
               title="정면 양쪽 어깨 높이차"
               userAvg={statics.front_horizontal_distance_sub_shoulder}
               unit="cm"
@@ -64,7 +61,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={90.35 * 2}
               sdAvg={1.55 * 2}
-              unitName="기울기"
               title="정면 양쪽 어깨 기울기"
               userAvg={Math.abs(statics.front_horizontal_angle_shoulder)}
               unit="°"
@@ -74,7 +70,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.17}
               sdAvg={0.58}
-              unitName="높이차"
               title="정면 양쪽 팔꿉 높이차"
               userAvg={statics.front_horizontal_distance_sub_elbow}
               unit="cm"
@@ -82,7 +77,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={90.47 * 2}
               sdAvg={1.58 * 2}
-              unitName="기울기"
               title="정면 양쪽 팔꿉 기울기"
               userAvg={statics.front_horizontal_angle_elbow}
               unit="°"
@@ -93,7 +87,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.25}
               sdAvg={0.67}
-              unitName="높이차"
               title="정면 양쪽 손목 높이차"
               userAvg={statics.front_horizontal_distance_sub_wrist}
               unit="cm"
@@ -101,7 +94,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={88.07}
               sdAvg={14.86}
-              unitName="기울기"
               title="정면 양쪽 손목 기울기"
               userAvg={Math.abs(statics.front_horizontal_angle_wrist)}
               unit="°"
@@ -112,7 +104,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={0}
               sdAvg={0.22}
-              unitName="높이차"
               title="정면 양쪽 골반 높이차"
               userAvg={statics.front_horizontal_distance_sub_hip}
               unit="cm"
@@ -120,7 +111,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={89.98 * 2}
               sdAvg={1.36 * 2}
-              unitName="기울기"
               title="정면 양쪽 골반 기울기"
               userAvg={Math.abs(statics.front_horizontal_angle_hip)}
               unit="°"
@@ -130,7 +120,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-0.12}
               sdAvg={0.36}
-              unitName="높이차"
               title="정면 양쪽 무릎 높이차"
               userAvg={statics.front_horizontal_distance_sub_knee}
               unit="cm"
@@ -138,7 +127,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={90.81 * 2}
               sdAvg={2.22 * 2}
-              unitName="기울기"
               title="정면 양쪽 무릎 기울기"
               userAvg={Math.abs(statics.front_horizontal_angle_knee)}
               unit="°"
@@ -148,7 +136,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={0.01}
               sdAvg={0.46}
-              unitName="높이차"
               title="정면 양쪽 발목 높이차"
               userAvg={statics.front_horizontal_distance_sub_ankle}
               unit="cm"
@@ -156,7 +143,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={89.94 * 2}
               sdAvg={3.89 * 2}
-              unitName="기울기"
               title="정면 양쪽 발목 기울기"
               userAvg={Math.abs(statics.front_horizontal_angle_ankle)}
               unit="°"
@@ -166,7 +152,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={89.94 * 2}
               sdAvg={3.89 * 2}
-              unitName="기울기"
               title="정면 양쪽 발목 기울기"
               userAvg={Math.abs(statics.front_horizontal_angle_ankle)}
               unit="°"
@@ -174,7 +159,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={-20.82}
               sdAvg={175.28}
-              unitName="각도"
               title="정면 코-골반-중심점 각도"
               userAvg={statics.back_vertical_angle_nose_center_hip - 90}
               unit="°"
@@ -184,7 +168,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={3.85}
               sdAvg={1.5}
-              unitName="거리"
               title="정면 중심점-발뒤꿈치 거리"
               userAvg={statics.back_horizontal_distance_heel_left}
               unit="cm"
@@ -192,7 +175,6 @@ const MeasureStaticFirst = React.memo(
             <ResultGraph
               defaultAvg={3.82}
               sdAvg={1.62}
-              unitName="거리"
               title="정면 오른쪽 무릎-뒤꿈치 거리"
               userAvg={statics.back_horizontal_distance_heel_right}
               unit="cm"

--- a/src/components/Measure/Static/Fourth.tsx
+++ b/src/components/Measure/Static/Fourth.tsx
@@ -38,7 +38,6 @@ const MeasureStaticFourth = React.memo(
             <ResultGraph
               defaultAvg={15.26}
               sdAvg={163.25}
-              unitName="각도"
               title="오른쪽 어깨-팔꿈치 각도"
               userAvg={statics.side_right_vertical_angle_shoulder_elbow}
               unit="°"
@@ -46,7 +45,6 @@ const MeasureStaticFourth = React.memo(
             <ResultGraph
               defaultAvg={136.37}
               sdAvg={57.53}
-              unitName="각도"
               title="오른쪽 팔꿈치-손목 각도"
               userAvg={statics.side_right_vertical_angle_elbow_wrist}
               unit="°"
@@ -56,7 +54,6 @@ const MeasureStaticFourth = React.memo(
             <ResultGraph
               defaultAvg={-22.63}
               sdAvg={175.7}
-              unitName="각도"
               title="오른쪽 골반-무릎 각도"
               userAvg={-statics.side_right_vertical_angle_hip_knee}
               unit="°"
@@ -64,7 +61,6 @@ const MeasureStaticFourth = React.memo(
             <ResultGraph
               defaultAvg={85.36}
               sdAvg={139.1}
-              unitName="각도"
               title="오른쪽 귀-어깨 각도"
               userAvg={statics.side_right_vertical_angle_ear_shoulder}
               unit="°"
@@ -74,7 +70,6 @@ const MeasureStaticFourth = React.memo(
             <ResultGraph
               defaultAvg={74.88}
               sdAvg={114.72}
-              unitName="각도"
               title="오른쪽 코-어깨 각도"
               userAvg={statics.side_right_vertical_angle_nose_shoulder}
               unit="°"
@@ -82,7 +77,6 @@ const MeasureStaticFourth = React.memo(
             <ResultGraph
               defaultAvg={1.65}
               sdAvg={1.23}
-              unitName="거리"
               title="중심점과 어깨와의 거리"
               userAvg={statics.side_right_horizontal_distance_shoulder}
               unit="cm"
@@ -92,7 +86,6 @@ const MeasureStaticFourth = React.memo(
             <ResultGraph
               defaultAvg={1.63}
               sdAvg={1.2}
-              unitName="거리"
               title="중심점과 골반과의 거리"
               userAvg={statics.side_right_horizontal_distance_hip}
               unit="cm"
@@ -101,7 +94,6 @@ const MeasureStaticFourth = React.memo(
             {/* <ResultGraph
               defaultAvg={5.01}
               sdAvg={3.43}
-              unitName="거리"
                 title="중심점과 새끼손가락과의 거리"
                 userAvg={statics.side_right_horizontal_distance_pinky}
                 unit="cm"

--- a/src/components/Measure/Static/Second.tsx
+++ b/src/components/Measure/Static/Second.tsx
@@ -42,14 +42,12 @@ const MeasureStaticSecond = React.memo(
               userAvg={
                 statics.front_elbow_align_angle_left_shoulder_elbow_wrist
               }
-              unitName="각도"
               unit="°"
             />
             <ResultGraph
               defaultAvg={-9.11}
               sdAvg={41.46}
               title="오른쪽 어깨-팔꿈치-손목 각도"
-              unitName="각도"
               userAvg={
                 statics.front_elbow_align_angle_right_shoulder_elbow_wrist
               }
@@ -61,7 +59,6 @@ const MeasureStaticSecond = React.memo(
               defaultAvg={18.87}
               sdAvg={26.73}
               title="왼쪽 팔꿈치 위-팔꿈치-손목 각도"
-              unitName="각도"
               userAvg={
                 statics.front_elbow_align_angle_left_upper_elbow_elbow_wrist
               }
@@ -70,7 +67,6 @@ const MeasureStaticSecond = React.memo(
             <ResultGraph
               defaultAvg={17.48}
               sdAvg={28.66}
-              unitName="각도"
               title="오른쪽 팔꿈치 위-팔꿈치-손목 각도"
               userAvg={
                 statics.front_elbow_align_angle_right_upper_elbow_elbow_wrist
@@ -83,7 +79,6 @@ const MeasureStaticSecond = React.memo(
                 defaultAvg={-0.12}
                 sdAvg={0.36}
                 title="중심점과 왼쪽 손목과의 거리"
-                unitName="거리"
                 userAvg={statics.front_elbow_align_distance_center_wrist_left}
                 unit="cm"
               />
@@ -91,7 +86,6 @@ const MeasureStaticSecond = React.memo(
                 defaultAvg={-0.12}
                 sdAvg={0.36}
                 title="중심점과 오른쪽 손목과의 거리"
-                unitName="거리"
                 userAvg={statics.front_elbow_align_distance_center_wrist_right}
                 unit="cm"
               />
@@ -101,7 +95,6 @@ const MeasureStaticSecond = React.memo(
               defaultAvg={2.34}
               sdAvg={1.89}
               title="왼쪽 손목-어깨 거리"
-              unitName="거리"
               userAvg={statics.front_elbow_align_distance_left_wrist_shoulder}
               unit="cm"
             />
@@ -109,7 +102,6 @@ const MeasureStaticSecond = React.memo(
               defaultAvg={2.3}
               sdAvg={1.74}
               title="오른쪽 손목-어깨 거리"
-              unitName="거리"
               userAvg={statics.front_elbow_align_distance_right_wrist_shoulder}
               unit="cm"
             />
@@ -119,7 +111,6 @@ const MeasureStaticSecond = React.memo(
               defaultAvg={-0.14}
               sdAvg={0.84}
               title="양 손목 높이 차이"
-              unitName="높이차"
               userAvg={statics.front_elbow_align_distance_wrist_height}
               unit="cm"
             />

--- a/src/components/Measure/Static/Sixth.tsx
+++ b/src/components/Measure/Static/Sixth.tsx
@@ -38,7 +38,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={0.04}
               sdAvg={0.29}
-              unitName="높이차"
               title="후면-앉은자세 양쪽 귀 높이차"
               userAvg={statics.back_sit_horizontal_distance_sub_ear}
               unit="cm"
@@ -46,7 +45,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={89.72 * 2}
               sdAvg={2.83 * 2}
-              unitName="기울기"
               title="후면-앉은자세 양쪽 귀 기울기"
               userAvg={statics.back_sit_horizontal_angle_ear + 180}
               unit="°"
@@ -56,7 +54,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={-0.02}
               sdAvg={0.63}
-              unitName="높이차"
               title="후면-앉은자세 양쪽 어깨 높이차"
               userAvg={statics.back_sit_horizontal_distance_sub_shoulder}
               unit="cm"
@@ -64,7 +61,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={90.13 * 2}
               sdAvg={2 * 2}
-              unitName="기울기"
               title="후면-앉은자세 양쪽 어깨 기울기"
               userAvg={statics.back_sit_horizontal_angle_shoulder + 180}
               unit="°"
@@ -74,7 +70,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={0.11}
               sdAvg={0.42}
-              unitName="높이차"
               title="후면-앉은자세 양쪽 골반 높이차"
               userAvg={statics.back_sit_horizontal_distance_sub_hip}
               unit="cm"
@@ -82,7 +77,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={89.42 * 2}
               sdAvg={2.52 * 2}
-              unitName="기울기"
               title="후면-앉은자세 양쪽 골반 기울기"
               userAvg={statics.back_sit_horizontal_angle_hip + 180}
               unit="°"
@@ -92,7 +86,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={90 - 65.63}
               sdAvg={3.94}
-              unitName="각도"
               title="후면-앉은자세 골반중앙-오른어깨-왼어깨 각도"
               userAvg={
                 statics.back_sit_vertical_angle_center_hip_right_shoulder_left_shoulder
@@ -102,7 +95,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={90 - 49.09}
               sdAvg={5.27}
-              unitName="각도"
               title="후면-앉은자세 왼어깨-골반중앙-오른어깨 각도"
               userAvg={
                 statics.back_sit_vertical_angle_left_shoulder_center_hip_right_shoulder
@@ -114,7 +106,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={90 - 43.64}
               sdAvg={4.48}
-              unitName="각도"
               title="후면-앉은자세 왼어깨-오른어깨-코 각도"
               userAvg={
                 statics.back_sit_vertical_angle_left_shoulder_right_shoulder_nose
@@ -124,7 +115,6 @@ const MeasureStaticSixth = React.memo(
             <ResultGraph
               defaultAvg={90 - 65.28}
               sdAvg={2.52}
-              unitName="각도"
               title="후면-앉은자세 오른어깨-왼어깨-골반중앙 각도"
               userAvg={
                 statics.back_sit_vertical_angle_right_shoulder_left_shoulder_center_hip

--- a/src/components/Measure/Static/Third.tsx
+++ b/src/components/Measure/Static/Third.tsx
@@ -38,7 +38,6 @@ const MeasureStaticThird = React.memo(
             <ResultGraph
               defaultAvg={32.55}
               sdAvg={163.01}
-              unitName="각도"
               title="왼쪽 어깨-팔꿈치 각도"
               userAvg={statics.side_left_vertical_angle_shoulder_elbow}
               unit="°"
@@ -46,7 +45,6 @@ const MeasureStaticThird = React.memo(
             <ResultGraph
               defaultAvg={129.93}
               sdAvg={71.34}
-              unitName="각도"
               title="왼쪽 팔꿈치-손목 각도"
               userAvg={statics.side_left_vertical_angle_elbow_wrist}
               unit="°"
@@ -56,7 +54,6 @@ const MeasureStaticThird = React.memo(
             <ResultGraph
               defaultAvg={-77.54}
               sdAvg={158.71}
-              unitName="각도"
               title="왼쪽 골반-무릎 각도"
               userAvg={statics.side_left_vertical_angle_hip_knee - 180}
               unit="°"
@@ -64,7 +61,6 @@ const MeasureStaticThird = React.memo(
             <ResultGraph
               defaultAvg={84.91}
               sdAvg={138.33}
-              unitName="각도"
               title="왼쪽 귀-어깨 각도"
               userAvg={statics.side_left_vertical_angle_ear_shoulder}
               unit="°"
@@ -74,7 +70,6 @@ const MeasureStaticThird = React.memo(
             <ResultGraph
               defaultAvg={78.81}
               sdAvg={111.75}
-              unitName="각도"
               title="왼쪽 코-어깨 각도"
               userAvg={statics.side_left_vertical_angle_nose_shoulder}
               unit="°"
@@ -82,7 +77,6 @@ const MeasureStaticThird = React.memo(
             <ResultGraph
               defaultAvg={1.93}
               sdAvg={1.29}
-              unitName="거리"
               title="중심점과 어깨와의 거리"
               userAvg={statics.side_left_horizontal_distance_shoulder}
               unit="cm"
@@ -92,7 +86,6 @@ const MeasureStaticThird = React.memo(
             <ResultGraph
               defaultAvg={2.16}
               sdAvg={1.28}
-              unitName="거리"
               title="중심점과 골반과의 거리"
               userAvg={statics.side_left_horizontal_distance_hip}
               unit="cm"


### PR DESCRIPTION
# [type] - TypeScript 오류 

## 수정된 TypeScript 오류
- ResultGraph 컴포넌트에서 unitName prop 제거
- DetailDynamic.tsx 및 모든 Static 컴포넌트에서 unitName prop 제거
- TypeScript 컴파일 오류 완전 해결
     
## 변경사항
- 8개 파일에서 98줄 삭제
- 모든 ResultGraph 사용처에서 unitName prop 제거

## 작업 이미지
- 작업 관련 첨부 이미지

## 작업 관련 이슈
- 이슈가 없을 시 공백 혹은 제거